### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
 name: Ruby
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@
 name: Ruby
 permissions:
   contents: read
-
+  pull-requests: write
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/exiftool-rb/exiftool_vendored.rb/security/code-scanning/1](https://github.com/exiftool-rb/exiftool_vendored.rb/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to explicitly define the least privileges required. Based on the workflow's operations:
1. The `actions/checkout` step requires `contents: read` to fetch the repository code.
2. The `ruby/setup-ruby` and `bundle install` steps do not require additional permissions.
3. The `paambaati/codeclimate-action` step for publishing code coverage may require `contents: read` to access repository files but does not need write permissions.

Thus, we will set `permissions: contents: read` at the root level of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
