### PR TITLE
Add macos-latest and windows-latest to platform build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         ruby-version: ['3.2', '3.3', '3.4', '4.0']
 
     steps:


### PR DESCRIPTION
I'm attempting to make a cross-platform tool that uses `exiftool`, but the vendored binaries don't seem compatible with windows. Adding this as a starting point to enable cross-platform support.